### PR TITLE
chore(TFD-9273): Run Veracode Scan

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,1 @@
+scalaVersion := "2.11.12"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -20,7 +20,6 @@ object Build extends sbt.Build {
   lazy val basicSettings = Seq(
     organization := "com.wandoulabs.avro",
     version := "0.1.6-talend-SNAPSHOT",
-    scalaVersion := "2.11.12",
     scalacOptions ++= Seq("-unchecked", "-deprecation"),
     resolvers ++= Seq(
       "Sonatype OSS Releases" at "https://oss.sonatype.org/content/repositories/releases",


### PR DESCRIPTION
Goal: Create a non-empty `build.sbt` file so that the repo can be scanned by Veracode.